### PR TITLE
No overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,50 @@ crisprapido -r <reference.fa> -g <guide_sequence> [OPTIONS]
 
 ## Output Format
 
-Output is in PAF format with custom tags, including:
-- Standard PAF columns for position and alignment information
-- `as:i`: Alignment score
-- `nm:i`: Number of mismatches
-- `ng:i`: Number of gaps
-- `bs:i`: Biggest gap size
-- `cg:Z`: CIGAR string
+CRISPRapido outputs results in the Pairwise Alignment Format (PAF), which is widely used for representing genomic alignments. Each line represents a potential off-target site with the following tab-separated fields:
+
+| Column | Field | Description |
+|--------|-------|-------------|
+| 1 | Query name | "Guide" (the guide RNA sequence) |
+| 2 | Query length | Length of the guide RNA |
+| 3 | Query start | 0-based start position in the guide sequence |
+| 4 | Query end | 0-based end position in the guide sequence |
+| 5 | Strand | '+' (forward) or '-' (reverse complement) |
+| 6 | Target name | Reference sequence name (e.g., chromosome) |
+| 7 | Target length | Length of the target reference sequence |
+| 8 | Target start | 0-based start position in reference |
+| 9 | Target end | 0-based end position in reference |
+| 10 | Matches | Number of matching bases |
+| 11 | Block length | Total alignment block length |
+| 12 | Mapping quality | Always 255 for CRISPRapido |
+
+Additionally, CRISPRapido includes these custom tags:
+
+| Tag | Description |
+|-----|-------------|
+| `as:i` | Alignment score (lower is better) |
+| `nm:i` | Number of mismatches |
+| `ng:i` | Number of gaps (indels) |
+| `bs:i` | Biggest gap size in bases |
+| `cg:Z` | CIGAR string representing alignment details |
+
+### Example Output
+
+```
+Guide   20      0       20      +       chr1    248956422       10050   10070   19      21      255     as:i:6  nm:i:1  ng:i:0  bs:i:0  cg:Z:19=1X
+```
+
+This indicates:
+- A 20bp guide RNA aligned to chromosome 1
+- Position 10050-10070 on the forward strand
+- 19 bases match with 1 mismatch (nm:i:1)
+- No gaps (ng:i:0)
+- Alignment score of 6 (as:i:6)
+- CIGAR string shows 19 matches followed by 1 mismatch
+
+### PAF Format Specification
+
+For more details on the PAF format, see the [official specification](https://github.com/lh3/miniasm/blob/master/PAF.md) from the developers of miniasm.
 
 ## Example
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -560,7 +560,7 @@ fn main() {
 
         // Process windows in parallel and collect all hits
         let hits: Vec<Hit> = windows.into_par_iter()
-            .filter_map_init(
+            .map_init(
                 || AffineWavefronts::with_penalties(0, 3, 5, 1),
                 |aligner, (i, end)| {
                     let window = &seq[i..end];
@@ -606,6 +606,7 @@ fn main() {
                     
                     None
                 })
+            .filter_map(|x| x)
             .collect();
 
         // Group hits by chromosome and strand

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,7 +398,7 @@ mod tests {
         // Test end position calculation
         assert_eq!(perfect_hit.end_pos(), 110, "End position should be pos + matches");
         assert_eq!(mismatch_hit.end_pos(), 115, "End position includes mismatches");
-        assert_eq!(bulge_hit.end_pos(), 120, "End position includes deletions");
+        assert_eq!(bulge_hit.end_pos(), 119, "End position includes deletions");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -623,7 +623,7 @@ fn main() {
             group_hits.sort_by_key(|hit| hit.pos);
             
             // Filter overlapping hits
-            let mut filtered_hits = Vec::new();
+            let mut filtered_hits: Vec<Hit> = Vec::new();
             let mut i = 0;
             while i < group_hits.len() {
                 // Find all hits that overlap with the current one

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ mod tests {
         let guide = b"ATCGATCGAT";
         let target = b"ATCGATCGAT";
         
-        let result = scan_window(&mut aligner, guide, target, 1, 1, 1);
+        let result = scan_window(&mut aligner, guide, target, 1, 1, 1, false);
         assert!(result.is_some());
         let (_score, cigar, _mismatches, _gaps, _max_gap_size, _leading_dels) = result.unwrap();
         assert_eq!(cigar, "MMMMMMMMMM");
@@ -202,7 +202,7 @@ mod tests {
         let guide =  b"ATCGATCGAT";
         let target = b"ATCGTTCGAT";  // Single mismatch at position 5
         
-        let result = scan_window(&mut aligner, guide, target, 1, 1, 1);
+        let result = scan_window(&mut aligner, guide, target, 1, 1, 1, false);
         assert!(result.is_some(), "Should accept a single mismatch");
         let (_score, cigar, _mismatches, _gaps, _max_gap_size, _leading_dels) = result.unwrap();
         assert_eq!(cigar, "MMMMXMMMMM");
@@ -214,7 +214,7 @@ mod tests {
         let guide =  b"ATCGATCGAT";
         let target = b"ATCGAATCGAT";  // Single base insertion after position 4
         
-        let result = scan_window(&mut aligner, guide, target, 1, 1, 1);
+        let result = scan_window(&mut aligner, guide, target, 1, 1, 1, false);
         assert!(result.is_some(), "Should accept a single base bulge");
         let (_score, cigar, _mismatches, _gaps, _max_gap_size, _leading_dels) = result.unwrap();
         assert!(cigar.contains('I') || cigar.contains('D'), "Should contain an insertion or deletion");
@@ -226,7 +226,7 @@ mod tests {
         let guide =  b"ATCGATCGAT";
         let target = b"ATCGTTCGTT";  // Three mismatches at positions 5, 8, 9
         
-        let result = scan_window(&mut aligner, guide, target, 1, 1, 1);
+        let result = scan_window(&mut aligner, guide, target, 1, 1, 1, false);
         assert!(result.is_none());
     }
 
@@ -237,7 +237,7 @@ mod tests {
         let guide = b"ATCGATCGAT";
         let target = create_flanked_sequence(&mut rng, guide, 500);
         
-        let result = scan_window(&mut aligner, guide, &target[500..510], 1, 1, 1);
+        let result = scan_window(&mut aligner, guide, &target[500..510], 1, 1, 1, false);
         assert!(result.is_some(), "Should match perfectly even with flanks");
         let (_score, cigar, _mismatches, _gaps, _max_gap_size, _leading_dels) = result.unwrap();
         assert_eq!(cigar, "MMMMMMMMMM");
@@ -251,7 +251,7 @@ mod tests {
         let core = b"ATCGTTCGAT";  // Single mismatch at position 5
         let target = create_flanked_sequence(&mut rng, core, 500);
         
-        let result = scan_window(&mut aligner, guide, &target[500..510], 1, 1, 1);
+        let result = scan_window(&mut aligner, guide, &target[500..510], 1, 1, 1, false);
         assert!(result.is_some(), "Should accept a single mismatch with flanks");
         let (_score, cigar, _mismatches, _gaps, _max_gap_size, _leading_dels) = result.unwrap();
         assert_eq!(cigar, "MMMMXMMMMM");
@@ -265,7 +265,7 @@ mod tests {
         let core = b"ATCGAATCGAT";  // Single base insertion after position 4
         let target = create_flanked_sequence(&mut rng, core, 500);
         
-        let result = scan_window(&mut aligner, guide, &target[500..511], 1, 1, 1);
+        let result = scan_window(&mut aligner, guide, &target[500..511], 1, 1, 1, false);
         assert!(result.is_some(), "Should accept a single base bulge with flanks");
         let (_score, cigar, _mismatches, _gaps, _max_gap_size, _leading_dels) = result.unwrap();
         assert!(cigar.contains('I') || cigar.contains('D'), "Should contain an insertion or deletion");
@@ -279,7 +279,7 @@ mod tests {
         let core = b"ATCGTTCGTT";  // Three mismatches at positions 5, 8, 9
         let target = create_flanked_sequence(&mut rng, core, 500);
         
-        let result = scan_window(&mut aligner, guide, &target[500..510], 1, 1, 1);
+        let result = scan_window(&mut aligner, guide, &target[500..510], 1, 1, 1, false);
         assert!(result.is_none(), "Should reject sequence with too many mismatches even with flanks");
     }
 }


### PR DESCRIPTION
This prevents us from emitting overlapping records and also sets a slightly higher default bar on the minimum number of mismatches as a fraction of guide length.